### PR TITLE
Melhorar texto em telas estreitas

### DIFF
--- a/html/js/main.js
+++ b/html/js/main.js
@@ -99,7 +99,7 @@ window.addEventListener('load', function () {
       position: 'inset',
       inset: {
         anchor: 'top-right',
-        step: 1,
+        step: 3,
         x: 20,
       },
     },

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0">
     <link href="/html/style/c3.min.css" rel="stylesheet">
     <link href="/html/style/main.css" rel="stylesheet">
     <script src="/html/js/d3.min.js" charset="utf-8"></script>


### PR DESCRIPTION
Melhora a renderização do texto em telas estreitas.

Antes
![Screen Shot 2020-06-24 at 18 35 49](https://user-images.githubusercontent.com/907946/85630141-8c3e9180-b649-11ea-9995-70cc338cc00d.png)


Depois
![Screen Shot 2020-06-24 at 18 35 39](https://user-images.githubusercontent.com/907946/85630155-92347280-b649-11ea-9c0a-b1f25ea1a1bc.png)

Tive que empilhar as legendas ou elas ficariam em cima das linhas de corte e do dia atual.

Closes #15.